### PR TITLE
Fix CMake sources declaration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,18 +9,18 @@ target_sources(type_name
 		$<INSTALL_INTERFACE:include/type_name/type_name.clang.hpp>
 		$<INSTALL_INTERFACE:include/type_name/type_name.clang.5.hpp>
 		$<INSTALL_INTERFACE:include/type_name/type_name.gcc.hpp>
-		$<INSTALL_INTERFACE:include/type_name/type_name.gcc.7_3.hpp>
-		$<INSTALL_INTERFACE:include/type_name/type_name.gcc.8_1.hpp>
+		$<INSTALL_INTERFACE:include/type_name/type_name.gcc.7.3.hpp>
+		$<INSTALL_INTERFACE:include/type_name/type_name.gcc.8.1.hpp>
 		$<INSTALL_INTERFACE:include/type_name/type_name.msvc.hpp>
-		$<INSTALL_INTERFACE:include/type_name/type_name.msvc.19_21.hpp>
+		$<INSTALL_INTERFACE:include/type_name/type_name.msvc.19.21.hpp>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.hpp>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.clang.hpp>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.clang.5.hpp>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.gcc.hpp>
-		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.gcc.7_3.hpp>
-		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.gcc.8_1.hpp>
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.gcc.7.3.hpp>
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.gcc.8.1.hpp>
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.msvc.hpp>
-		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.msvc.19_21.hpp>
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/type_name/type_name.msvc.19.21.hpp>
 )
 target_include_directories(type_name
 	INTERFACE


### PR DESCRIPTION
The last commit causes the sources declaration to be wrong. This causes several problems when including the project into others. target_link_libraries will fail for instance which requires one to use target_include_directories manually which is very suboptimal. Fixing the names causes all problems to vanish.